### PR TITLE
Remove unwrap (again!)

### DIFF
--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -21,7 +21,6 @@ cc = { version = "1.0", features = ["parallel"] }
 
 [dependencies]
 libc = "0.2"
-unwrap = "1.1.0"
 
 [lib]
 name = "libsodium_sys"


### PR DESCRIPTION
Accidentally spotted that `unwrap` wasn't removed completely from dependencies. Fixed it now.