### PR TITLE
Relax the assumptions about `lsb_release` output

### DIFF
--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -1,8 +1,8 @@
 extern crate num_cpus;
 extern crate pkg_config;
 
-const VERSION: &'static str = "1.0.17";
-const MIN_VERSION: &'static str = "1.0.12";
+const VERSION: &str = "1.0.17";
+const MIN_VERSION: &str = "1.0.12";
 
 #[cfg(not(windows))]
 fn main() {
@@ -18,34 +18,32 @@ fn main() {
 
     if force_build {
         should_build = true;
-    } else {
-        if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
-            println!("cargo:rustc-link-search=native={}", lib_dir);
-            let mode = match env::var_os("SODIUM_STATIC") {
-                Some(_) => "static",
-                None => "dylib",
-            };
-            println!("cargo:rustc-link-lib={0}=sodium", mode);
+    } else if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
+        println!("cargo:rustc-link-search=native={}", lib_dir);
+        let mode = match env::var_os("SODIUM_STATIC") {
+            Some(_) => "static",
+            None => "dylib",
+        };
+        println!("cargo:rustc-link-lib={0}=sodium", mode);
+        println!(
+            "cargo:warning=Using unknown libsodium version. This crate is tested against \
+             {} and may not be fully compatible with other versions.",
+            VERSION
+        );
+    } else if let Ok(lib_details) = pkg_config::Config::new()
+        .atleast_version(MIN_VERSION)
+        .probe("libsodium")
+    {
+        println!(" === found libsodium: {:#?}", lib_details);
+        if lib_details.version != VERSION {
             println!(
-                "cargo:warning=Using unknown libsodium version. This crate is tested against \
-                 {} and may not be fully compatible with other versions.",
-                VERSION
+                "cargo:warning=Using libsodium version {}. This crate is tested against {} \
+                 and may not be fully compatible with {}.",
+                lib_details.version, VERSION, lib_details.version
             );
-        } else if let Ok(lib_details) = pkg_config::Config::new()
-            .atleast_version(MIN_VERSION)
-            .probe("libsodium")
-        {
-            println!(" === found libsodium: {:#?}", lib_details);
-            if lib_details.version != VERSION {
-                println!(
-                    "cargo:warning=Using libsodium version {}. This crate is tested against {} \
-                     and may not be fully compatible with {}.",
-                    lib_details.version, VERSION, lib_details.version
-                );
-            }
-        } else {
-            should_build = true;
         }
+    } else {
+        should_build = true;
     }
 
     if should_build {
@@ -63,7 +61,7 @@ fn main() {
         let mut source_dir = env::var("OUT_DIR").unwrap() + "/source";
         // Avoid issues with paths containing spaces by falling back to using /tmp
         let target = env::var("TARGET").unwrap();
-        if install_dir.contains(" ") {
+        if install_dir.contains(' ') {
             let fallback_path = "/tmp/".to_string() + &basename + "/" + &target;
             install_dir = fallback_path.clone() + "/installed";
             source_dir = fallback_path.clone() + "/source";
@@ -107,7 +105,7 @@ fn main() {
         let _ = fs::remove_file(gz_path);
 
         // Run `./configure`
-        let target_parts: Vec<&str> = target.split("-").collect();
+        let target_parts: Vec<&str> = target.split('-').collect();
         let mut target_arch = target_parts[0];
         if target_arch == "aarch64" {
             target_arch = "arm64";
@@ -119,12 +117,12 @@ fn main() {
         let (cc, mut cflags) = if target.contains("i686") {
             (
                 format!("{} -m32", build.get_compiler().path().display()),
-                env::var("CFLAGS").unwrap_or(String::from(" -march=i686 -O3")),
+                env::var("CFLAGS").unwrap_or_else(|_| String::from(" -march=i686 -O3")),
             )
         } else {
             (
                 format!("{}", build.get_compiler().path().display()),
-                env::var("CFLAGS").unwrap_or(String::from(" -march=native -O3")),
+                env::var("CFLAGS").unwrap_or_else(|_| String::from(" -march=native -O3")),
             )
         };
 

--- a/libsodium-sys/src/crypto_box.rs
+++ b/libsodium-sys/src/crypto_box.rs
@@ -9,7 +9,7 @@ pub const crypto_box_ZEROBYTES: usize = crypto_box_curve25519xsalsa20poly1305_ZE
 pub const crypto_box_BOXZEROBYTES: usize = crypto_box_curve25519xsalsa20poly1305_BOXZEROBYTES;
 pub const crypto_box_MACBYTES: usize = crypto_box_curve25519xsalsa20poly1305_MACBYTES;
 pub const crypto_box_PRIMITIVE: &str = "curve25519xsalsa20poly1305";
-pub const crypto_box_SEALBYTES: usize = (crypto_box_PUBLICKEYBYTES + crypto_box_MACBYTES);
+pub const crypto_box_SEALBYTES: usize = crypto_box_PUBLICKEYBYTES + crypto_box_MACBYTES;
 
 
 extern {

--- a/src/crypto/box_/curve25519xsalsa20poly1305.rs
+++ b/src/crypto/box_/curve25519xsalsa20poly1305.rs
@@ -4,8 +4,8 @@
 //!
 //! This function is conjectured to meet the standard notions of privacy and
 //! third-party unforgeability.
+
 use crate::randombytes::randombytes_into;
-use ffi;
 #[cfg(not(feature = "std"))]
 use prelude::*;
 

--- a/src/crypto/kx/x25519blake2b.rs
+++ b/src/crypto/kx/x25519blake2b.rs
@@ -1,7 +1,5 @@
 //! `x25519blake2b` is the current default key exchange scheme of `libsodium`.
 
-use ffi;
-
 /// Number of bytes in a `PublicKey`.
 pub const PUBLICKEYBYTES: usize = ffi::crypto_kx_PUBLICKEYBYTES as usize;
 

--- a/src/crypto/pwhash/scryptsalsa208sha256.rs
+++ b/src/crypto/pwhash/scryptsalsa208sha256.rs
@@ -1,7 +1,7 @@
 //! `crypto_pwhash_scryptsalsa208sha256`, a particular combination of Scrypt, Salsa20/8
 //! and SHA-256
+
 use crate::randombytes::randombytes_into;
-use ffi;
 use libc::c_ulonglong;
 
 /// Number of bytes in a `Salt`.

--- a/src/crypto/scalarmult/curve25519.rs
+++ b/src/crypto/scalarmult/curve25519.rs
@@ -3,7 +3,6 @@
 //! This function is conjectured to be strong. For background see Bernstein,
 //! "Curve25519: new Diffie-Hellman speed records," Lecture Notes in Computer
 //! Science 3958 (2006), 207–228, http://cr.yp.to/papers.html#curve25519.
-use ffi;
 
 /// Number of bytes in a `GroupElement`.
 pub const GROUPELEMENTBYTES: usize = ffi::crypto_scalarmult_curve25519_BYTES;

--- a/src/crypto/sealedbox/curve25519blake2bxsalsa20poly1305.rs
+++ b/src/crypto/sealedbox/curve25519blake2bxsalsa20poly1305.rs
@@ -1,5 +1,5 @@
 //! A particular combination of Curve25519, Blake2B, Salsa20 and Poly1305.
-use ffi;
+
 #[cfg(not(feature = "std"))]
 use prelude::*;
 

--- a/src/crypto/secretbox/xsalsa20poly1305.rs
+++ b/src/crypto/secretbox/xsalsa20poly1305.rs
@@ -4,8 +4,8 @@
 //!
 //! This function is conjectured to meet the standard notions of privacy and
 //! authenticity.
+
 use crate::randombytes::randombytes_into;
-use ffi;
 #[cfg(not(feature = "std"))]
 use prelude::*;
 

--- a/src/crypto/shorthash/siphash24.rs
+++ b/src/crypto/shorthash/siphash24.rs
@@ -1,6 +1,6 @@
 //! `SipHash-2-4`
+
 use crate::randombytes::randombytes_into;
-use ffi;
 use libc::c_ulonglong;
 
 /// Number of bytes in a `Digest`.

--- a/src/crypto/sign/ed25519.rs
+++ b/src/crypto/sign/ed25519.rs
@@ -2,7 +2,7 @@
 //! [Ed25519](http://ed25519.cr.yp.to/). This function is conjectured to meet the
 //! standard notion of unforgeability for a public-key signature scheme under
 //! chosen-message attacks.
-use ffi;
+
 use libc::c_ulonglong;
 #[cfg(not(feature = "std"))]
 use prelude::*;

--- a/src/crypto/verify.rs
+++ b/src/crypto/verify.rs
@@ -1,5 +1,4 @@
 //! Constant-time comparison of fixed-size vecs
-use ffi;
 
 /// `verify_16()` returns `true` if `x[0]`, `x[1]`, ..., `x[15]` are the
 /// same as `y[0]`, `y[1]`, ..., `y[15]`. Otherwise it returns `false`.

--- a/src/randombytes.rs
+++ b/src/randombytes.rs
@@ -1,5 +1,5 @@
 //! Cryptographic random number generation.
-use ffi;
+
 #[cfg(not(feature = "std"))]
 use prelude::*;
 use std::iter::repeat;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,4 @@
 //! Libsodium utility functions
-use ffi;
 
 /// `memzero()` tries to effectively zero out the data in `x` even if
 /// optimizations are being applied to the code.

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,6 +1,5 @@
 //! Libsodium version functions
-use ffi;
-use libc;
+
 use std::slice;
 use std::str;
 


### PR DESCRIPTION
The build.rs sources was contain a strong assumption about the
lsb_release output wrt the distribution version.

The output was expected to have Major.Minor form.

But for Debian (testing) the lsb_release command returns "testing" as
the version.

The previous assumption stops the build of the libsodium-sys crate.

Closes #32