### PR TITLE
make randombytes function unsafe

### DIFF
--- a/src/crypto/aead/aead_macros.rs
+++ b/src/crypto/aead/aead_macros.rs
@@ -179,8 +179,8 @@ mod test_m {
         for i in 0..256usize {
             let k = gen_key();
             let n = gen_nonce();
-            let ad = randombytes(i);
-            let m = randombytes(i);
+            let ad = unsafe { randombytes(i) };
+            let m = unsafe { randombytes(i) };
             let c = seal(&m, Some(&ad), &n, &k);
             let m2 = open(&c, Some(&ad), &n, &k).unwrap();
             assert_eq!(m, m2);
@@ -192,8 +192,8 @@ mod test_m {
         for i in 0..32usize {
             let k = gen_key();
             let n = gen_nonce();
-            let mut ad = randombytes(i);
-            let m = randombytes(i);
+            let mut ad = unsafe { randombytes(i) };
+            let m = unsafe { randombytes(i) };
             let mut c = seal(&m, Some(&ad), &n, &k);
             for j in 0..c.len() {
                 c[j] ^= 0x20;
@@ -215,8 +215,8 @@ mod test_m {
         for i in 0..256usize {
             let k = gen_key();
             let n = gen_nonce();
-            let ad = randombytes(i);
-            let mut m = randombytes(i);
+            let ad = unsafe { randombytes(i) };
+            let mut m = unsafe { randombytes(i) };
             let m2 = m.clone();
             let t = seal_detached(&mut m, Some(&ad), &n, &k);
             open_detached(&mut m, Some(&ad), &t, &n, &k).unwrap();
@@ -229,8 +229,8 @@ mod test_m {
         for i in 0..32usize {
             let k = gen_key();
             let n = gen_nonce();
-            let mut ad = randombytes(i);
-            let mut m = randombytes(i);
+            let mut ad = unsafe { randombytes(i) };
+            let mut m = unsafe { randombytes(i) };
             let mut t = seal_detached(&mut m, Some(&ad), &n, &k);
             for j in 0..m.len() {
                 m[j] ^= 0x20;
@@ -258,8 +258,8 @@ mod test_m {
         for i in 0..256usize {
             let k = gen_key();
             let n = gen_nonce();
-            let ad = randombytes(i);
-            let mut m = randombytes(i);
+            let ad = unsafe { randombytes(i) };
+            let mut m = unsafe { randombytes(i) };
 
             let c = seal(&m, Some(&ad), &n, &k);
             let t = seal_detached(&mut m, Some(&ad), &n, &k);

--- a/src/crypto/auth/auth_macros.rs
+++ b/src/crypto/auth/auth_macros.rs
@@ -85,7 +85,7 @@ mod test_m {
     fn test_auth_verify_tamper() {
         for i in 0..32usize {
             let k = gen_key();
-            let mut m = randombytes(i);
+            let mut m = unsafe { randombytes(i) };
             let Tag(mut tagbuf) = authenticate(&m, &k);
             for j in 0..m.len() {
                 m[j] ^= 0x20;
@@ -106,7 +106,7 @@ mod test_m {
         use crate::test_utils::round_trip;
         for i in 0..256usize {
             let k = gen_key();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let tag = authenticate(&m, &k);
             round_trip(k);
             round_trip(tag);
@@ -128,7 +128,7 @@ mod bench_m {
     fn bench_auth(b: &mut test::Bencher) {
         let k = gen_key();
         let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| {
-            randombytes(*s)
+            unsafe { randombytes(*s) }
         }).collect();
         b.iter(|| {
             for m in ms.iter() {
@@ -141,7 +141,7 @@ mod bench_m {
     fn bench_verify(b: &mut test::Bencher) {
         let k = gen_key();
         let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| {
-            randombytes(*s)
+            unsafe { randombytes(*s) }
         }).collect();
         let tags: Vec<Tag> = ms.iter().map(|m| {
             authenticate(&m, &k)
@@ -244,7 +244,7 @@ mod test_s {
     fn test_auth_eq_auth_state() {
         for i in 0..256usize {
             let k = gen_key();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let tag = authenticate(&m, &k);
             let mut state = State::init(&k[..]);
             state.update(&m);
@@ -257,7 +257,7 @@ mod test_s {
     fn test_auth_eq_auth_state_chunked() {
         for i in 0..256usize {
             let k = gen_key();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let tag = authenticate(&m, &k);
             let mut state = State::init(&k[..]);
             for c in m.chunks(1) {

--- a/src/crypto/box_/curve25519xsalsa20poly1305.rs
+++ b/src/crypto/box_/curve25519xsalsa20poly1305.rs
@@ -292,7 +292,7 @@ mod test {
         for i in 0..256usize {
             let (pk1, sk1) = gen_keypair();
             let (pk2, sk2) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let c = seal(&m, &n, &pk1, &sk2);
             let opened = open(&c, &n, &pk2, &sk1);
@@ -310,7 +310,7 @@ mod test {
             let k2 = precompute(&pk2, &sk1);
             let PrecomputedKey(k2buf) = k2;
             assert!(k1buf == k2buf);
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let c = seal_precomputed(&m, &n, &k1);
             let opened = open_precomputed(&c, &n, &k2);
@@ -323,7 +323,7 @@ mod test {
         for i in 0..32usize {
             let (pk1, sk1) = gen_keypair();
             let (pk2, sk2) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut c = seal(&m, &n, &pk1, &sk2);
             for j in 0..c.len() {
@@ -341,7 +341,7 @@ mod test {
             let (pk2, sk2) = gen_keypair();
             let k1 = precompute(&pk1, &sk2);
             let k2 = precompute(&pk2, &sk1);
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut c = seal_precomputed(&m, &n, &k1);
             for j in 0..c.len() {
@@ -357,7 +357,7 @@ mod test {
         for i in 0..256usize {
             let (pk1, sk1) = gen_keypair();
             let (pk2, sk2) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut buf = m.clone();
             let tag = seal_detached(&mut buf, &n, &pk1, &sk2);
@@ -371,7 +371,7 @@ mod test {
         for i in 0..256usize {
             let (pk1, sk1) = gen_keypair();
             let (pk2, sk2) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut c = seal(&m, &n, &pk1, &sk2);
             let tag = Tag::from_slice(&c[..MACBYTES]).unwrap();
@@ -386,7 +386,7 @@ mod test {
         for i in 0..256usize {
             let (pk1, sk1) = gen_keypair();
             let (pk2, sk2) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut buf = vec![0; MACBYTES];
             buf.extend_from_slice(&m);
@@ -402,7 +402,7 @@ mod test {
         for i in 0..32usize {
             let (pk1, sk1) = gen_keypair();
             let (pk2, sk2) = gen_keypair();
-            let mut m = randombytes(i);
+            let mut m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut tag = seal_detached(&mut m, &n, &pk1, &sk2);
             for j in 0..m.len() {
@@ -446,7 +446,7 @@ mod test {
             let (pk2, sk2) = gen_keypair();
             let k1 = precompute(&pk1, &sk2);
             let k2 = precompute(&pk2, &sk1);
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut buf = m.clone();
             let tag = seal_detached_precomputed(&mut buf, &n, &k1);
@@ -462,7 +462,7 @@ mod test {
             let (pk2, sk2) = gen_keypair();
             let k1 = precompute(&pk1, &sk2);
             let k2 = precompute(&pk2, &sk1);
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut c = seal_precomputed(&m, &n, &k1);
             let tag = Tag::from_slice(&c[..MACBYTES]).unwrap();
@@ -479,7 +479,7 @@ mod test {
             let (pk2, sk2) = gen_keypair();
             let k1 = precompute(&pk1, &sk2);
             let k2 = precompute(&pk2, &sk1);
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut buf = vec![0; MACBYTES];
             buf.extend_from_slice(&m);
@@ -497,7 +497,7 @@ mod test {
             let (pk2, sk2) = gen_keypair();
             let k1 = precompute(&pk1, &sk2);
             let k2 = precompute(&pk2, &sk1);
-            let mut m = randombytes(i);
+            let mut m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut tag = seal_detached_precomputed(&mut m, &n, &k1);
             for j in 0..m.len() {
@@ -661,7 +661,7 @@ mod bench {
     fn bench_seal_open(b: &mut test::Bencher) {
         let (pk, sk) = gen_keypair();
         let n = gen_nonce();
-        let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| randombytes(*s)).collect();
+        let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| unsafe {randombytes(*s)}).collect();
         b.iter(|| {
             for m in ms.iter() {
                 open(&seal(m, &n, &pk, &sk), &n, &pk, &sk).unwrap();

--- a/src/crypto/hash/hash_macros.rs
+++ b/src/crypto/hash/hash_macros.rs
@@ -96,7 +96,7 @@ mod test_encode {
     #[test]
     fn test_serialisation() {
         for i in 0..32usize {
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let d = hash(&m[..]);
             round_trip(d);
         }
@@ -116,7 +116,7 @@ mod bench_m {
     #[bench]
     fn bench_hash(b: &mut test::Bencher) {
         let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| {
-            randombytes(*s)
+            unsafe { randombytes(*s) }
         }).collect();
         b.iter(|| {
             for m in ms.iter() {

--- a/src/crypto/pwhash/scryptsalsa208sha256.rs
+++ b/src/crypto/pwhash/scryptsalsa208sha256.rs
@@ -210,7 +210,7 @@ mod test {
     #[test]
     fn test_pwhash_verify() {
         for i in 0..32usize {
-            let pw = randombytes(i);
+            let pw = unsafe { randombytes(i) };
             let pwh = pwhash(&pw, OPSLIMIT_INTERACTIVE, MEMLIMIT_INTERACTIVE).unwrap();
             assert!(pwhash_verify(&pwh, &pw));
         }
@@ -219,7 +219,7 @@ mod test {
     #[test]
     fn test_pwhash_verify_tamper() {
         for i in 0..16usize {
-            let mut pw = randombytes(i);
+            let mut pw = unsafe { randombytes(i) };
             let pwh = pwhash(&pw, OPSLIMIT_INTERACTIVE, MEMLIMIT_INTERACTIVE).unwrap();
             for j in 0..pw.len() {
                 pw[j] ^= 0x20;
@@ -234,7 +234,7 @@ mod test {
     fn test_serialisation() {
         use crate::test_utils::round_trip;
         for i in 0..32usize {
-            let pw = randombytes(i);
+            let pw = unsafe { randombytes(i) };
             let pwh = pwhash(&pw, OPSLIMIT_INTERACTIVE, MEMLIMIT_INTERACTIVE).unwrap();
             let salt = gen_salt();
             round_trip(pwh);

--- a/src/crypto/sealedbox/curve25519blake2bxsalsa20poly1305.rs
+++ b/src/crypto/sealedbox/curve25519blake2bxsalsa20poly1305.rs
@@ -65,7 +65,7 @@ mod test {
     fn test_seal_open() {
         for i in 0..256usize {
             let (pk, sk) = box_::gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let c = seal(&m, &pk);
             let opened = open(&c, &pk, &sk);
             assert!(Ok(m) == opened);
@@ -76,7 +76,7 @@ mod test {
     fn test_seal_open_tamper() {
         for i in 0..32usize {
             let (pk, sk) = box_::gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let mut c = seal(&m, &pk);
             for j in 0..c.len() {
                 c[j] ^= 0x20;

--- a/src/crypto/secretbox/xsalsa20poly1305.rs
+++ b/src/crypto/secretbox/xsalsa20poly1305.rs
@@ -140,7 +140,7 @@ mod test {
     fn test_seal_open() {
         for i in 0..256usize {
             let k = gen_key();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let c = seal(&m, &n, &k);
             let opened = open(&c, &n, &k);
@@ -152,7 +152,7 @@ mod test {
     fn test_seal_open_tamper() {
         for i in 0..32usize {
             let k = gen_key();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut c = seal(&m, &n, &k);
             for i in 0..c.len() {
@@ -171,7 +171,7 @@ mod test {
     fn test_seal_open_detached() {
         for i in 0..256usize {
             let k = gen_key();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut buf = m.clone();
             let tag = seal_detached(&mut buf, &n, &k);
@@ -184,7 +184,7 @@ mod test {
     fn test_seal_combined_then_open_detached() {
         for i in 0..256usize {
             let k = gen_key();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut c = seal(&m, &n, &k);
             let tag = Tag::from_slice(&c[..MACBYTES]).unwrap();
@@ -198,7 +198,7 @@ mod test {
     fn test_seal_detached_then_open_combined() {
         for i in 0..256usize {
             let k = gen_key();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut buf = vec![0; MACBYTES];
             buf.extend_from_slice(&m);
@@ -213,7 +213,7 @@ mod test {
     fn test_seal_open_detached_tamper() {
         for i in 0..32usize {
             let k = gen_key();
-            let mut m = randombytes(i);
+            let mut m = unsafe { randombytes(i) };
             let n = gen_nonce();
             let mut tag = seal_detached(&mut m, &n, &k);
             for j in 0..m.len() {
@@ -318,7 +318,7 @@ mod bench {
     fn bench_seal_open(b: &mut test::Bencher) {
         let k = gen_key();
         let n = gen_nonce();
-        let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| randombytes(*s)).collect();
+        let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| unsafe { randombytes(*s) }).collect();
         b.iter(|| {
             for m in ms.iter() {
                 open(&seal(&m, &n, &k), &n, &k).unwrap();

--- a/src/crypto/shorthash/siphash24.rs
+++ b/src/crypto/shorthash/siphash24.rs
@@ -135,7 +135,7 @@ mod test {
         use crate::test_utils::round_trip;
         for i in 0..64usize {
             let k = gen_key();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let d = shorthash(&m[..], &k);
             round_trip(k);
             round_trip(d);
@@ -155,7 +155,7 @@ mod bench {
     #[bench]
     fn bench_shorthash(b: &mut test::Bencher) {
         let k = gen_key();
-        let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| randombytes(*s)).collect();
+        let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| unsafe { randombytes(*s) }).collect();
         b.iter(|| {
             for m in ms.iter() {
                 shorthash(m, &k);

--- a/src/crypto/sign/ed25519.rs
+++ b/src/crypto/sign/ed25519.rs
@@ -268,7 +268,7 @@ mod test {
     fn test_streaming_sign() {
         for i in 0..256usize {
             let (pk, sk) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let mut creation_state = State::init();
             creation_state.update(&m);
             let sig = creation_state.finalize(&sk);
@@ -284,7 +284,7 @@ mod test {
         let mut creation_state = State::init();
         let mut validator_state = State::init();
         for i in 0..64usize {
-            let chunk = randombytes(i);
+            let chunk = unsafe { randombytes(i) };
             creation_state.update(&chunk);
             validator_state.update(&chunk);
         }
@@ -296,7 +296,7 @@ mod test {
     fn test_sign_verify() {
         for i in 0..256usize {
             let (pk, sk) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let sm = sign(&m, &sk);
             let m2 = verify(&sm, &pk);
             assert!(Ok(m) == m2);
@@ -307,7 +307,7 @@ mod test {
     fn test_sign_verify_tamper() {
         for i in 0..32usize {
             let (pk, sk) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let mut sm = sign(&m, &sk);
             for j in 0..sm.len() {
                 sm[j] ^= 0x20;
@@ -321,7 +321,7 @@ mod test {
     fn test_sign_verify_detached() {
         for i in 0..256usize {
             let (pk, sk) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let sig = sign_detached(&m, &sk);
             assert!(verify_detached(&sig, &m, &pk));
         }
@@ -331,7 +331,7 @@ mod test {
     fn test_sign_verify_detached_tamper() {
         for i in 0..32usize {
             let (pk, sk) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let Signature(mut sig) = sign_detached(&m, &sk);
             for j in 0..SIGNATUREBYTES {
                 sig[j] ^= 0x20;
@@ -349,7 +349,7 @@ mod test {
             randombytes_into(&mut seedbuf);
             let seed = Seed(seedbuf);
             let (pk, sk) = keypair_from_seed(&seed);
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let sm = sign(&m, &sk);
             let m2 = verify(&sm, &pk);
             assert!(Ok(m) == m2);
@@ -364,7 +364,7 @@ mod test {
             randombytes_into(&mut seedbuf);
             let seed = Seed(seedbuf);
             let (pk, sk) = keypair_from_seed(&seed);
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let mut sm = sign(&m, &sk);
             for j in 0..sm.len() {
                 sm[j] ^= 0x20;
@@ -446,7 +446,7 @@ mod test {
         use crate::test_utils::round_trip;
         for i in 0..256usize {
             let (pk, sk) = gen_keypair();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let sig = sign_detached(&m, &sk);
             round_trip(pk);
             round_trip(sk);
@@ -494,7 +494,7 @@ mod bench {
     #[bench]
     fn bench_sign(b: &mut test::Bencher) {
         let (_, sk) = gen_keypair();
-        let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| randombytes(*s)).collect();
+        let ms: Vec<Vec<u8>> = BENCH_SIZES.iter().map(|s| unsafe { randombytes(*s) }).collect();
         b.iter(|| {
             for m in ms.iter() {
                 sign(m, &sk);
@@ -508,7 +508,7 @@ mod bench {
         let sms: Vec<Vec<u8>> = BENCH_SIZES
             .iter()
             .map(|s| {
-                let m = randombytes(*s);
+                let m = unsafe { randombytes(*s) };
                 sign(&m, &sk)
             })
             .collect();

--- a/src/crypto/stream/stream_macros.rs
+++ b/src/crypto/stream/stream_macros.rs
@@ -115,7 +115,7 @@ mod test_m {
         for i in 0..1024usize {
             let k = gen_key();
             let n = gen_nonce();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let c = stream_xor(&m, &n, &k);
             let m2 = stream_xor(&c, &n, &k);
             assert!(m == m2);
@@ -127,7 +127,7 @@ mod test_m {
         for i in 0..1024usize {
             let k = gen_key();
             let n = gen_nonce();
-            let m = randombytes(i);
+            let m = unsafe { randombytes(i) };
             let mut c = m.clone();
             let s = stream(c.len(), &n, &k);
             for (e, v) in c.iter_mut().zip(s.iter()) {
@@ -143,7 +143,7 @@ mod test_m {
         for i in 0..1024usize {
             let k = gen_key();
             let n = gen_nonce();
-            let mut m = randombytes(i);
+            let mut m = unsafe { randombytes(i) };
             let mut c = m.clone();
             let s = stream(c.len(), &n, &k);
             for (e, v) in c.iter_mut().zip(s.iter()) {

--- a/src/randombytes.rs
+++ b/src/randombytes.rs
@@ -9,13 +9,11 @@ use std::iter::repeat;
 /// THREAD SAFETY: `randombytes()` is thread-safe provided that you have
 /// called `sodiumoxide::init()` once before using any other function
 /// from sodiumoxide.
-pub fn randombytes(size: usize) -> Vec<u8> {
-    unsafe {
-        let mut buf: Vec<u8> = repeat(0u8).take(size).collect();
-        let pbuf = buf.as_mut_ptr();
-        ffi::randombytes_buf(pbuf, size);
-        buf
-    }
+pub unsafe fn randombytes(size: usize) -> Vec<u8> {
+    let mut buf: Vec<u8> = repeat(0u8).take(size).collect();
+    let pbuf = buf.as_mut_ptr();
+    ffi::randombytes_buf(pbuf, size);
+    buf
 }
 
 /// `randombytes_into()` fills a buffer `buf` with random data.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,7 +46,7 @@ mod test {
         use crate::randombytes::randombytes;
 
         for i in 0usize..256 {
-            let x = randombytes(i);
+            let x = unsafe { randombytes(i) };
             assert!(memcmp(&x, &x));
             let mut y = x.clone();
             assert!(memcmp(&x, &y));
@@ -54,7 +54,7 @@ mod test {
             assert!(!memcmp(&x, &y));
             assert!(!memcmp(&y, &x));
 
-            y = randombytes(i);
+            y = unsafe { randombytes(i) };
             if x == y {
                 assert!(memcmp(&x, &y))
             } else {


### PR DESCRIPTION
Hello, I found a soundness issue in this crate.
https://github.com/exonum/exonum_sodiumoxide/blob/fa93330a73ddd2d8a9f70b9e6440fe330615da6a/src/randombytes.rs#L12-L19
It is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the randombytes function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.
The following program panics:
```rust
fn main() {
    extern crate exonum_sodiumoxide;
    let mut b:i128 = 4294967296;
    let _ = exonum_sodiumoxide::randombytes::randombytes(b as usize);
}
``` 
Output:
```
    Finished dev [unoptimized + debuginfo] target(s) in 12.04s
     Running `target\debug\hello.exe`
error: process didn't exit successfully: `target\debug\hello.exe` (exit code: 0xc0000409, STATUS_STACK_BUFFER_OVERRUN)
``` 